### PR TITLE
feat:两种方式实现文字省略

### DIFF
--- a/src/pages/DirectiveDemo.vue
+++ b/src/pages/DirectiveDemo.vue
@@ -22,10 +22,19 @@
       <!-- 123_456_789 -->
       <!-- <div v-format-text.money:4="','">123456789</div> -->
       <!-- 1234,4567,89 -->
-      <div v-formatMoney="'_'">123456789</div>
+      <!-- <div v-formatMoney="'_'">123456789</div> -->
       <!-- 1234_4567_89 -->
       <!-- <div v-format-text>abcdefghi</div> -->
       <!-- abc,def,ghi- -->
+    </div>
+
+    <div class="ellipsis">
+      <div v-ellipsis:220>
+        默认通过样式实现文字省略通过样式实现文字省略通过样式实现文字省略通过样式实现文字省略
+      </div>
+      <div v-ellipsis:10="'js'">
+        通过js实现文字省略通过js实现文字省略通过js实现文字省略通过js实现文字省略通过js实现文字省略
+      </div>
     </div>
   </div>
 </template>

--- a/src/utils/directive/ellipsis.js
+++ b/src/utils/directive/ellipsis.js
@@ -1,0 +1,33 @@
+const ellipsis = {
+  beforeMount(el, binding) {
+    console.log("ellipsis-binding", binding);
+    const { value = "style", arg = 10 } = binding;
+
+    // js实现文字省略
+    function substrLength(element, length = 10) {
+      //elementId：元素id，length：需保留字符串长度
+      const text = element;
+      let result = "";
+      console.log("length", text.innerText.length);
+      if (text.innerText.length > length) {
+        result = text.innerText.substr(0, length) + "...";
+      } else {
+        result = text.innerText;
+      }
+      text.innerText = result;
+    }
+
+    if (value === "style") {
+      // 方案一: 通过样式控制省略
+      el.style.width = `${binding.arg || 100}px`;
+      el.style.whiteSpace = "nowrap";
+      el.style.overflow = "hidden";
+      el.style.textOverflow = "ellipsis";
+    } else {
+      const len = +arg + 1;
+      substrLength(el, len);
+    }
+  },
+};
+
+export default ellipsis;

--- a/src/utils/directive/index.js
+++ b/src/utils/directive/index.js
@@ -1,11 +1,13 @@
 import realImg from "./realImg";
 import hideText from "./hideText";
 import formatMoney from "./formatText";
+import ellipsis from "./ellipsis";
 
 const directives = {
   realImg,
   hideText,
   formatMoney,
+  ellipsis,
 };
 
 export default {


### PR DESCRIPTION
1.默认使用样式实现文字省略，传width，比如只显示100px，则传100
2.使用js实现文字省略，传文字长度比如只显示10个字则传10